### PR TITLE
Deployed contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+solidity/build/

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -1,4 +1,9 @@
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
+  compilers: {
+    solc: {
+      version: "^0.4.20",
+    }
+  }
 };

--- a/solidity/truffle.js
+++ b/solidity/truffle.js
@@ -3,11 +3,9 @@ module.exports = {
   // to customize your Truffle configuration!
   networks: {
     development: {
-      host: "localhost",
-      port: 8545,
-      network_id: "*", // Match any network id
-      from: '0XDeployer_ETH_Address',
-      gas: 4612388
+      host: "127.0.0.1",
+      port: 7545,
+      network_id: "5777", // Match any network id
     }
   }
 };


### PR DESCRIPTION
I made these changes:
1. Deleted the redundant configurations in `truffle.js` and modified it according to Ganache's default server configurations.
2. The solidity compiler version (0.4.20) is specified in `truffle-config.js`. The default version of `truffle` is currently too high.